### PR TITLE
create simple card component without style

### DIFF
--- a/src/components/ProductCard.js
+++ b/src/components/ProductCard.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles({
+  root: {
+    width: "20em",
+    margin: "1em"
+  },
+  media: {
+    height: "15em",
+  },
+});
+
+export default function ProductCard({productInfo, addToCartHandler}) {
+  const classes = useStyles();
+
+  return (
+    <Card className={classes.root}>
+      <CardActionArea>
+        <CardMedia
+          className={classes.media}
+          image={productInfo.imageUrl}
+          title={productInfo.name}
+        />
+        <CardContent>
+          <Typography gutterBottom variant="h5" component="h2">
+            {productInfo.name}
+          </Typography>
+          <Typography variant="body2" color="textSecondary" component="p">
+            $ {productInfo.price}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+      <CardActions>
+        <Button size="small" color="primary" onClick={addToCartHandler}>
+          Add to cart
+        </Button>
+      </CardActions>
+    </Card>
+  );
+}

--- a/src/pages/Category.js
+++ b/src/pages/Category.js
@@ -1,9 +1,20 @@
 import React from 'react';
+import ProductCard from '../components/ProductCard';
+import { productsResponse } from '../dummydata/dummy_products';
+
+const myDummyProduct = productsResponse.data[3];
 
 const Category = () => {
+    // dummy function as example for the Card props:
+    const addToCartAction = () => {
+        alert("you added a product to the cart :)");
+    };
     return (
         <div>
-            components go here
+            <ProductCard 
+            productInfo={myDummyProduct} 
+            addToCartHandler={addToCartAction}
+            />
         </div>
     );
 };


### PR DESCRIPTION
This PR includes changes to the following files:

- `components/ProductCard` (new): created component and defined props (`productInfo` object and `addToCartHandler` function).
- `pages/Category` : imported `ProductCard` component and called it with dummy data and a simple alert function as props. 

This PR does not include a defined style or functionality (hence the simple alert function), as they will be defined in later tickets as the rest of the components are incorporated. 

It looks like this:
<img width="348" alt="Screen Shot 2021-08-30 at 13 45 27" src="https://user-images.githubusercontent.com/82424931/131390481-74aee19f-72fb-442c-8409-1a317a0653ad.png">
<img width="588" alt="Screen Shot 2021-08-30 at 13 50 02" src="https://user-images.githubusercontent.com/82424931/131390500-8b6328be-cc7b-4153-9314-f60c0f9b5542.png">
