### PR TITLE
add reusable cards-container

### DIFF
--- a/src/components/CardsContainer.js
+++ b/src/components/CardsContainer.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import ProductCard from './ProductCard';
+
+const getProductsForDisplay = (allProducts,myFilter,keepOnly5) => {
+    const filtered = allProducts.filter((product) => {
+        return product.title === myFilter;
+    });
+    if (keepOnly5) {
+        return filtered.slice(0,5);
+    } else {
+        return filtered;
+    }
+};
+
+const CardsContainer = ({rowName, rawData, top5}) => {
+    const productsForDisplay = getProductsForDisplay(rawData,rowName,top5);
+    const addToCartAction = () => {
+        alert("you added a product to the cart :)");
+    };
+    //console.log(rowName);
+    return (
+        <div>
+            <Grid 
+            container
+            direction="column"
+            justifyContent="center"
+            alignItems="center"
+            >
+                <Grid item xs={12}><h2>{rowName}</h2></Grid> 
+            <Grid
+            container
+            direction="row"
+            justifyContent="center"
+            alignItems="flex-start"
+            spacing={2}
+            >
+                {
+                    productsForDisplay.map((product, index) => (
+                        <Grid item key={index}>
+                            <ProductCard
+                            productInfo={product} 
+                            addToCartHandler={addToCartAction}
+                            isCardSmall={top5}
+                            />
+                        </Grid>
+                    ))
+                }
+            </Grid>
+            </Grid>
+            
+        </div>
+    );
+};
+
+export default CardsContainer;

--- a/src/components/ProductCard.js
+++ b/src/components/ProductCard.js
@@ -2,23 +2,65 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
-import CardActions from '@material-ui/core/CardActions';
+//import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
-import Button from '@material-ui/core/Button';
+//import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
+import AddShoppingCartIcon from '@material-ui/icons/AddShoppingCart';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles({
-  root: {
-    width: "20em",
-    margin: "1em"
-  },
-  media: {
-    height: "15em",
-  },
-});
 
-export default function ProductCard({productInfo, addToCartHandler}) {
+export default function ProductCard({productInfo, addToCartHandler, isCardSmall}) {
+  const cardWidth = isCardSmall ? 12 : 20;
+  const cardHeightRatio = isCardSmall ? 1.0 : 0.88;
+  const cardTitleSize = isCardSmall ? "subtitle1" : "h6";
+  const priceLabelSize = `body${isCardSmall ? 2 : 1}`;
+  const useStyles = makeStyles({
+    root: {
+      width: `${cardWidth}em`,
+      height: `${cardWidth*cardHeightRatio}em`,
+    },
+    media: {
+      height: `${cardWidth*0.75}em`,
+    },
+    
+    cardInfo: {
+      display: 'flex',
+      flexDirection: "row",
+      justifyContent: "flex-end",
+      alignItems: "center",
+      padding: "0em",
+      margin: "0em",
+    },
+    cardTitle: {
+      lineHeight: "1.2em",
+    },
+    cardRight: {
+      display: 'flex',
+      flexDirection: "row",
+      justifyContent: "flex-end",
+      
+    },
+    cardLeft: {
+      display: 'flex',
+      flexDirection: "row",
+      justifyContent: "flex-start",
+      alignItems: "center",
+      
+    },
+    addToCartButton: {
+      width: "1em",
+      height: "1em",
+      backgroundColor: "grey",
+    },
+    addToCartIcon: {
+      width: "0.8em",
+      height: "0.8em",
+      color: "white",
+    }
+  });
   const classes = useStyles();
 
   return (
@@ -29,20 +71,29 @@ export default function ProductCard({productInfo, addToCartHandler}) {
           image={productInfo.imageUrl}
           title={productInfo.name}
         />
-        <CardContent>
-          <Typography gutterBottom variant="h5" component="h2">
-            {productInfo.name}
-          </Typography>
-          <Typography variant="body2" color="textSecondary" component="p">
-            $ {productInfo.price}
-          </Typography>
+        <CardContent styles={{backgroundColor: "yellow"}}>
+          <Grid container className={classes.cardInfo}>
+            <Grid item className={classes.cardLeft} xs={8}>
+              <Typography variant={cardTitleSize} className={classes.cardTitle}>
+                {productInfo.name}
+              </Typography>
+            </Grid>
+            <Grid container  xs={4}>
+              <Grid item className={classes.cardRight} xs={12}>
+                <Typography variant={priceLabelSize} color="textSecondary">
+                  $ {productInfo.price}
+                </Typography>
+              </Grid>
+              <Grid item className={classes.cardRight} xs={12}>
+                  <IconButton className={classes.addToCartButton} variant="contained" aria-label="add to shopping cart" onClick={addToCartHandler}>
+                    <AddShoppingCartIcon className={classes.addToCartIcon} />
+                  </IconButton>
+              </Grid>
+            </Grid>
+            
+          </Grid>
         </CardContent>
       </CardActionArea>
-      <CardActions>
-        <Button size="small" color="primary" onClick={addToCartHandler}>
-          Add to cart
-        </Button>
-      </CardActions>
     </Card>
   );
 }

--- a/src/pages/Category.js
+++ b/src/pages/Category.js
@@ -1,21 +1,34 @@
 import React from 'react';
-import ProductCard from '../components/ProductCard';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import CardsContainer from '../components/CardsContainer';
 import { productsResponse } from '../dummydata/dummy_products';
 
-const myDummyProduct = productsResponse.data[3];
+
+const useStyles = makeStyles({
+    categoryContainer: {
+      padding: "1em",
+      
+    },
+  });
+
+const dummyProductsAll = productsResponse.data;
+
+const dummyCategory = dummyProductsAll[10].title;
 
 const Category = () => {
-    // dummy function as example for the Card props:
-    const addToCartAction = () => {
-        alert("you added a product to the cart :)");
-    };
+    const classes = useStyles();
     return (
-        <div>
-            <ProductCard 
-            productInfo={myDummyProduct} 
-            addToCartHandler={addToCartAction}
-            />
-        </div>
+        <Grid container className={classes.categoryContainer}>
+            <Grid item xs={12} className={classes.categoryRow}>
+                <CardsContainer
+                        rowName={dummyCategory}
+                        rawData={dummyProductsAll}
+                        top5={false}
+                        
+                />
+            </Grid>
+        </Grid>
     );
 };
 

--- a/src/pages/Directory.js
+++ b/src/pages/Directory.js
@@ -1,10 +1,45 @@
 import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+
+import CardsContainer from '../components/CardsContainer';
+import { productsResponse } from '../dummydata/dummy_products';
+
+const dummyProductsAll = productsResponse.data;
+
+const dummyProductCategories = new Set(dummyProductsAll.map((product) => {
+    return product.title;
+}));
+
+const useStyles = makeStyles({
+    directoryContainer: {
+      padding: "1em",
+      
+    },
+    categoryRow: {
+        margin: "1em 0em 1em 0em",
+    },
+  });
 
 const Directory = () => {
+    const classes = useStyles();
     return (
-        <div>
-            components go here (is this the same as shop page ?)
-        </div>
+        <Grid container className={classes.directoryContainer}>
+            {
+                [...dummyProductCategories].map((category, index) => (
+                    <Grid item xs={12} className={classes.categoryRow}>
+                        <CardsContainer
+                        key={index}
+                        rowName={category}
+                        rawData={dummyProductsAll}
+                        top5={true}
+                        
+                    />
+                    </Grid>
+                ))
+            }
+            
+        </Grid>
     );
 };
 


### PR DESCRIPTION
This PR adds the CardsContainer component that is recycled for the Category and Directory pages, its props allow it to adapt to these two different formats.
It looks like this in those respective formats:

Directory

<img width="1112" alt="Screen Shot 2021-08-31 at 11 11 49" src="https://user-images.githubusercontent.com/82424931/131538940-e5637ac0-342e-4640-944f-93815c7deb42.png">

Category

<img width="1114" alt="Screen Shot 2021-08-31 at 11 12 22" src="https://user-images.githubusercontent.com/82424931/131538946-e487cee5-f2d7-47a2-815a-85efc6561bd0.png">
