### PR TITLE
28/user authentication localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "axios": "^0.21.1",
+    "jwt-decode": "^3.1.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.1",

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -10,7 +10,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from '@material-ui/core/Typography';
 
 import AccountService from "../api/AccountService";
-import JWTUtil from "../util/JWTUtil";
+//import JWTUtil from "../util/JWTUtil";
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -35,11 +35,6 @@ const Login = () => {
   const classes = useStyles();
   const history = useHistory();
 
-  // const handleSubmit = (e) => {
-  //   e.preventDefault();
-  //   console.log(username, password);
-  // };
-
   const handleSubmit = async (e) => {
     e.preventDefault();
     const user = {
@@ -47,12 +42,10 @@ const Login = () => {
       email: email,
       password: password,
     };
-    console.log(user);
 
     AccountService.logInUser(user)
       .then((result) => {
-        //console.log(result.data.token);
-        //JWTUtil.
+        localStorage.setItem("jwt", result.data.token);
         history.push("/");
       })
       .catch((error) => {

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -10,6 +10,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from '@material-ui/core/Typography';
 
 import AccountService from "../api/AccountService";
+import JWTUtil from "../util/JWTUtil";
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -50,7 +51,8 @@ const Login = () => {
 
     AccountService.logInUser(user)
       .then((result) => {
-        console.log(result.data.token);
+        //console.log(result.data.token);
+        //JWTUtil.
         history.push("/");
       })
       .catch((error) => {

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -9,6 +9,7 @@ import IconButton from "@material-ui/core/IconButton";
 import ShoppingCartIcon from "@material-ui/icons/ShoppingCart";
 
 import ShoppingCartPreview from "./ShoppingCartPreview";
+import JWTUtil from "../util/JWTUtil";
 
 const useStyles = makeStyles((theme) => ({
   "@global": {
@@ -92,6 +93,15 @@ const Nav = () => {
             >
               Shop
             </Link>
+            {JWTUtil.isSignedIn() ?
+            <Link
+              variant="button"
+              color="textPrimary"
+              onClick={JWTUtil.signOut}
+              className={classes.link}
+            >
+              Log Out
+            </Link> :
             <Link
               variant="button"
               color="textPrimary"
@@ -99,7 +109,7 @@ const Nav = () => {
               className={classes.link}
             >
               Log In
-            </Link>
+            </Link>}
             <IconButton aria-label="cart" onClick={handleClick}>
               <StyledBadge badgeContent={4} color="secondary">
                 <ShoppingCartIcon />

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -41,14 +41,17 @@ const Signup = () => {
     };
 
     AccountService.signUpUser(user)
-      .then(AccountService.logInUser(user))
-      .then((result) => {
-          localStorage.setItem("jwt", result.token);
-          alert('Signed up successfully, now you are logged in to your new account');
-          history.push("/");
+      .then((result1) => {
+        console.log(result1);
+        return AccountService.logInUser(user);
+      })
+      .then((result2) => {
+        localStorage.setItem("jwt", result2.data.token);
+        alert('Signed up successfully, now you are logged in to your new account');
+        history.push("/");
       })
       .catch((error) => {
-        alert(error?.response?.data?.message || "something went wrong :(");
+        alert(error?.response?.data?.message || error);// 
       });
   };
 

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -41,19 +41,14 @@ const Signup = () => {
     };
 
     AccountService.signUpUser(user)
+      .then(AccountService.logInUser(user))
       .then((result) => {
-        AccountService.logInUser(user)
-          .then((result) => {
           localStorage.setItem("jwt", result.token);
           alert('Signed up successfully, now you are logged in to your new account');
           history.push("/");
-        })
-        .catch((error) => {
-          alert("sign in did not work");
-        });
       })
       .catch((error) => {
-        alert(error.response.data.message || "something went wrong :(");
+        alert(error?.response?.data?.message || "something went wrong :(");
       });
   };
 

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -39,15 +39,21 @@ const Signup = () => {
       email: email,
       password: password,
     };
-    console.log(user);
 
     AccountService.signUpUser(user)
       .then((result) => {
-        alert('Signed up succesfully, now you can log in!');
-        history.push("/login");
+        AccountService.logInUser(user)
+          .then((result) => {
+          localStorage.setItem("jwt", result.token);
+          alert('Signed up successfully, now you are logged in to your new account');
+          history.push("/");
+        })
+        .catch((error) => {
+          alert("sign in did not work");
+        });
       })
       .catch((error) => {
-        alert('Registration failed :(');
+        alert(error.response.data.message || "something went wrong :(");
       });
   };
 

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -41,12 +41,8 @@ const Signup = () => {
     };
 
     AccountService.signUpUser(user)
-      .then((result1) => {
-        console.log(result1);
-        return AccountService.logInUser(user);
-      })
-      .then((result2) => {
-        localStorage.setItem("jwt", result2.data.token);
+      .then((result) => {
+        localStorage.setItem("jwt", result.data.token);
         alert('Signed up successfully, now you are logged in to your new account');
         history.push("/");
       })

--- a/src/util/JWTUtil.js
+++ b/src/util/JWTUtil.js
@@ -6,13 +6,12 @@ const jwtDecode = (tokenString) => {
 
 const isSignedIn = () => {
     try {
-        //const myJWT = 
-        jwtDecode(localStorage.getItem("jwt"));
-        // const isTokenActive = ( new Date( parseInt(myJWT.exp) * 1000 ) - new Date(Date.now()) ) > 0;
-        // if (!isTokenActive) {
-        //     localStorage.removeItem("jwt");
-        // }
-        return true;//isTokenActive;
+        const myJWT = jwtDecode(localStorage.getItem("jwt"));
+        const isTokenActive = ( new Date( parseInt(myJWT.exp) * 1000 ) - new Date(Date.now()) ) > 0;
+        if (!isTokenActive) {
+            localStorage.removeItem("jwt");
+        }
+        return isTokenActive;
     } catch {
         return false;
     }

--- a/src/util/JWTUtil.js
+++ b/src/util/JWTUtil.js
@@ -1,0 +1,33 @@
+import jwt_decode from "jwt-decode";
+
+const jwtDecode = (tokenString) => {
+    return jwt_decode(tokenString);
+};
+
+const isSignedIn = () => {
+    try {
+        //const myJWT = 
+        jwtDecode(localStorage.getItem("jwt"));
+        // const isTokenActive = ( new Date( parseInt(myJWT.exp) * 1000 ) - new Date(Date.now()) ) > 0;
+        // if (!isTokenActive) {
+        //     localStorage.removeItem("jwt");
+        // }
+        return true;//isTokenActive;
+    } catch {
+        return false;
+    }
+};
+
+const signOut = () => {
+    localStorage.removeItem("jwt");
+    //window.location.reload(); // creo q esto es mala practica pq refresca TODA la pag
+    // debemos encontrar la forma de actualizar solo el boton de sign in/out
+};
+
+const JWTUtil = {
+  jwtDecode,
+  isSignedIn,
+  signOut
+};
+
+export default JWTUtil;


### PR DESCRIPTION
This PR implements login authentication with localhost in JWT. In this way it is possible to stay logged in after having exited the browser (you can test it manually).

It required to make a new folder/file in `src/util/JWTUtil.js` .

It also provides a provisional conditional rendering for the nav links for login/logout. Current condition is based on the `localStorage` token so it is only possible to see this change in the nav by refreshing the page manually. In future PRs we have to implement a login-related variable in context/redux that we can use to re-render just that button in the navbar using hooks, etc.

For testing this PR, you can do the following 4 independent manual tests:

- (try to) login with a non-existent account (should get an error alert) and refresh page, look at nav, still shows ‘log in'
- login with an existing account (should redirect to home) and refresh page, look at nav, now shows ‘log out’. Press it and refresh page. Now you should see ‘log in’ again.
- (try to) sign up with an existing account (should get an error alert) and refresh page, look at nav, still shows ‘log in’.
- sign up with a non-existent account (should show success alert and redirect to home) and refresh page, look at nav, , now shows ‘log out’. Press it and refresh page. Now you should see ‘log in’ again.