### PR TITLE
51/fix unnecessary refresh in redirects

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -37,11 +37,15 @@ export default function Router() {
           <Route path="/shop">
             <Shop />
           </Route>
-          <Route path="/sign-up">
-            <SignUp />
-          </Route>
           <CustomRedirect 
-            path="/login"
+            path="/sign-up"
+            shouldDisplay={!storeToken}
+            redirectTo="/"
+          >
+            <SignUp />
+          </CustomRedirect>
+          <CustomRedirect 
+            path="/log-in"
             shouldDisplay={!storeToken}
             redirectTo="/"
           >
@@ -56,7 +60,7 @@ export default function Router() {
           <CustomRedirect 
             path="/checkout"
             shouldDisplay={storeToken}
-            redirectTo="/login"
+            redirectTo="/log-in"
           >
             <CheckOut />
           </CustomRedirect>

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -5,7 +5,7 @@ import TextField from "@material-ui/core/TextField";
 import Button from "@material-ui/core/Button";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Checkbox from "@material-ui/core/Checkbox";
-import Link from "@material-ui/core/Link";
+import { Link } from 'react-router-dom';
 import Grid from "@material-ui/core/Grid";
 import Typography from '@material-ui/core/Typography';
 
@@ -128,9 +128,11 @@ const Login = () => {
         </Button>
         <Grid container>
           <Grid item>
-            <Link href="/sign-up" variant="body2">
+            
+            <Link to='/sign-up' variant="body2">
               {"Don't have an account? Sign Up"}
             </Link>
+            
           </Grid>
         </Grid>
       </form>

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -4,7 +4,7 @@ import { makeStyles, withStyles } from "@material-ui/core/styles";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
-import Link from "@material-ui/core/Link";
+import { Link } from 'react-router-dom';
 import Badge from "@material-ui/core/Badge";
 import IconButton from "@material-ui/core/IconButton";
 import ShoppingCartIcon from "@material-ui/icons/ShoppingCart";
@@ -86,7 +86,7 @@ const Nav = () => {
           <Link
             variant="button"
             color="textPrimary"
-            href="/"
+            to="/"
             className={classes.link}
           >
             <img src="/dummylogo.png" alt="logo" className={classes.logo} />
@@ -104,7 +104,7 @@ const Nav = () => {
             <Link
               variant="button"
               color="textPrimary"
-              href="/directory"
+              to="/directory"
               className={classes.link}
             >
               Shop
@@ -113,7 +113,7 @@ const Nav = () => {
             <Link
               variant="button"
               color="textPrimary"
-              href="/"
+              toolbarTitle="/"
               onClick={handleLogOut}
               className={classes.link}
             >
@@ -122,7 +122,7 @@ const Nav = () => {
             <Link
               variant="button"
               color="textPrimary"
-              href="/login"
+              to="/login"
               className={classes.link}
             >
               Log In

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -6,6 +6,7 @@ import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
 import { Link } from 'react-router-dom';
 import Badge from "@material-ui/core/Badge";
+import Button from "@material-ui/core/Button";
 import IconButton from "@material-ui/core/IconButton";
 import ShoppingCartIcon from "@material-ui/icons/ShoppingCart";
 import ShoppingCartPreview from "./ShoppingCartPreview";
@@ -110,15 +111,11 @@ const Nav = () => {
               Shop
             </Link>
             {token ?
-            <Link
-              variant="button"
-              color="textPrimary"
-              toolbarTitle="/"
+            <Button
               onClick={handleLogOut}
-              className={classes.link}
             >
               Log Out
-            </Link> :
+            </Button> :
             <Link
               variant="button"
               color="textPrimary"

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -31,6 +31,7 @@ const useStyles = makeStyles((theme) => ({
   },
   link: {
     margin: theme.spacing(1, 1.5),
+    textDecorationLine: "none"
   },
   logo: {
     maxWidth: 40,
@@ -92,38 +93,45 @@ const Nav = () => {
           >
             <img src="/dummylogo.png" alt="logo" className={classes.logo} />
           </Link>
-
-          <Typography
-            variant="h6"
-            color="inherit"
-            noWrap
-            className={classes.toolbarTitle}
-          >
-            Shop
-          </Typography>
-          <nav>
-            <Link
-              variant="button"
-              color="textPrimary"
-              to="/directory"
-              className={classes.link}
+          
+            <Typography
+              variant="h6"
+              color="inherit"
+              noWrap
+              className={classes.toolbarTitle}
             >
               Shop
-            </Link>
+            </Typography>
+          
+          <nav>
+            <Button>
+              <Link
+                variant="button"
+                color="textPrimary"
+                to="/directory"
+                className={classes.link}
+              >
+                Shop
+              </Link>
+            </Button>
             {token ?
             <Button
+              className={classes.link}
               onClick={handleLogOut}
             >
               Log Out
             </Button> :
-            <Link
-              variant="button"
-              color="textPrimary"
-              to="/log-in"
-              className={classes.link}
-            >
-              Log In
-            </Link>}
+            <Button>
+              <Link
+                variant="button"
+                color="textPrimary"
+                to="/log-in"
+                className={classes.link}
+              >
+                Log In
+              </Link>
+            </Button>
+            }
             <IconButton aria-label="cart" onClick={handleClick}>
               <StyledBadge badgeContent={cartCount} color="secondary">
                 <ShoppingCartIcon />

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -119,7 +119,7 @@ const Nav = () => {
             <Link
               variant="button"
               color="textPrimary"
-              to="/login"
+              to="/log-in"
               className={classes.link}
             >
               Log In

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router";
+import { useDispatch } from "react-redux";
 import { makeStyles } from "@material-ui/core";
 import TextField from "@material-ui/core/TextField";
 import Button from "@material-ui/core/Button";
@@ -32,12 +31,7 @@ const Signup = () => {
   const [password, setPassword] = useState("");
   const [error, setError] = useState({'username': false, 'email': false, 'password': false, 'regex': false})
   const classes = useStyles();
-  const history = useHistory();
   const dispatch = useDispatch();
-  const token = useSelector((state) => state.user.token);
-
-  if (token) history.push("/");
-
   
   const handleSubmit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
This PR fixes the unnecessary page refresh that was happening when clicking any link that redirects.

The issue had to do with the wrong `Link` component being imported (from `material-ui`, the good one is from `react-router-dom`). After correcting the import, it was also necessary to change the `href` property to `to`. You can see how in this way, for example, the console does not get restarted anymore because the page is not refreshed when navigating between routes.

There was a bug that became a fatal error in the log out link, it was changed to a button and the issue was fixed. 

A minor consequence of these changes is that the styling looks uneven/weirg between links in the nav but this can be easily fixed in another ticket.

Additionally, the `SignUp` page was wrapped in `CustomRedirect` in the `Router` because this was missing from a previous PR.