### PR TITLE
add spinner with timeout

### DIFF
--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -18,13 +18,13 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const Spinner = () => {
+const Spinner = ({message}) => {
   const classes = useStyles();
 
   return (
     <div className={classes.root}>
       <CircularProgress className={classes.center}/>
-      <Typography className={classes.center}>Loading...</Typography>
+      <Typography className={classes.center}>{message}</Typography>
     </div>
   );
 }

--- a/src/pages/Category.js
+++ b/src/pages/Category.js
@@ -25,7 +25,7 @@ const Category = () => {
     dispatch(setProducts());
   }, [dispatch]);
 
-  return loading ? <Spinner /> : error ? <div>{error}</div> :(
+  return loading ? <Spinner message="Loading..." /> : error ? <div>{error}</div> :(
     <Grid container className={classes.categoryContainer}>
       <Grid item xs={12} className={classes.categoryRow}>
         <CardsContainer

--- a/src/pages/Directory.js
+++ b/src/pages/Directory.js
@@ -2,13 +2,10 @@ import React, { useEffect } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 
-import Spinner from '../components/Spinner'
+import Spinner from '../components/Spinner';
 import CardsContainer from '../components/CardsContainer';
 import { useSelector, useDispatch } from 'react-redux';
-import  { setProducts }  from "../redux/products/reducer"
-
-// import { productsResponse } from '../dummydata/dummy_products';
-
+import  { setProducts }  from "../redux/products/reducer";
 
 const useStyles = makeStyles({
     directoryContainer: {
@@ -35,7 +32,7 @@ const Directory = () => {
         return product.title;
     }));
 
-    return  loading ? <Spinner /> : error ? <div>{error}</div> : (
+    return  loading ? <Spinner message="Loading..." /> : error ? <div>{error}</div> : (
         <Grid container className={classes.directoryContainer}>
             {
                 [...productCategories].map((category, index) => (

--- a/src/pages/SuccessfulPayment.js
+++ b/src/pages/SuccessfulPayment.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 
+import Spinner from '../components/Spinner';
 
 const useStyles = makeStyles(theme => ({
     styledMessage: {
@@ -12,8 +13,15 @@ const useStyles = makeStyles(theme => ({
 
 
 const SuccessfulPayment = () => {
+    const [isLoading, setIsLoading] = useState(true);
     const classes = useStyles();
-    return (
+    useEffect(()=>{
+        const timer = setTimeout(() => {
+            setIsLoading(false);
+        }, 3000);
+    return () => clearTimeout(timer);
+    },[]);
+    return  isLoading ? <Spinner message="Processing your payment..."/> : (
         <div className={classes.styledMessage}>
             <Typography
             variant="h6"


### PR DESCRIPTION
This PR implements the payment request simulation by adding a `setTimeout` of 3 seconds (and rendering the `Spinner` component) before rendering the `SuccessfulPayment` component. 

It was necessary to refactor `Spinner` a little bit by adding a `message` prop so the text can be set according to the context in which it is rendered. Thus, `Category` and `Directory` files were also modified to provide the new prop and keep working.