### PR TITLE
Add link to redirect to home after successful payment

### DIFF
--- a/src/pages/SuccessfulPayment.js
+++ b/src/pages/SuccessfulPayment.js
@@ -1,45 +1,59 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
-import { useDispatch } from 'react-redux';
-import { deleteCart, toggleVisibility} from '../redux/cart/reducer';
+import { useDispatch } from "react-redux";
+import { deleteCart, toggleVisibility } from "../redux/cart/reducer";
+import { Link } from "react-router-dom";
 
-import Spinner from '../components/Spinner';
+import Spinner from "../components/Spinner";
 
-const useStyles = makeStyles(theme => ({
-    styledMessage: {
-        textAlign: 'center',
-        margin: '2rem',
-    }
-}))
-
+const useStyles = makeStyles((theme) => ({
+  styledMessage: {
+    textAlign: "center",
+    margin: "2rem",
+  },
+  link: {
+    margin: theme.spacing(1, 1.5),
+    textDecorationLine: "none",
+  },
+}));
 
 const SuccessfulPayment = () => {
-    const [isLoading, setIsLoading] = useState(true);
-    const classes = useStyles();
-    const dispatch = useDispatch();
+  const [isLoading, setIsLoading] = useState(true);
+  const classes = useStyles();
+  const dispatch = useDispatch();
 
-    useEffect(() => {
-        dispatch(deleteCart());
-        dispatch(toggleVisibility(true));
-        const timer = setTimeout(() => {
-            setIsLoading(false);
-        }, 3000);
-        return () => clearTimeout(timer);
-    }, [dispatch]);
-    return  isLoading ? <Spinner message="Processing your payment..."/> : (
-        <div className={classes.styledMessage}>
-            <Typography
-            variant="h6"
-            color="inherit"
-            noWrap
-            className={classes.styledMessage}
-          >
-            Your payment has been successfully processed!
-          </Typography>
-            <img src="success.png" alt="Success"></img>
-        </div>
-    );
+  useEffect(() => {
+    dispatch(deleteCart());
+    dispatch(toggleVisibility(true));
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [dispatch]);
+  return isLoading ? (
+    <Spinner message="Processing your payment..." />
+  ) : (
+    <div className={classes.styledMessage}>
+      <Typography
+        variant="h6"
+        color="inherit"
+        noWrap
+        className={classes.styledMessage}
+      >
+        Your payment has been successfully processed!
+      </Typography>
+      <img src="success.png" alt="Success"></img>
+      <Link
+        variant="button"
+        color="textPrimary"
+        to="/"
+        className={classes.link}
+      >
+        <Typography>Continue shopping</Typography>
+      </Link>
+    </div>
+  );
 };
 
 export default SuccessfulPayment;


### PR DESCRIPTION
This PR includes a Link in successful payment to redirect to the home page.
Originally it was intended that the user couldn't go back to the payment form once the payment was concluded but, according to [this](https://stackoverflow.com/questions/63351913/how-to-redirect-to-home-page-after-clicking-browser-back-button-when-on-a-parti) we decided to not implement it, since the shopping cart is emptied after payment going back to the form does not represent a problem for duplicating the payment.